### PR TITLE
Fix negative captured totals in score snapshots

### DIFF
--- a/game_core/scoring.py
+++ b/game_core/scoring.py
@@ -49,8 +49,8 @@ class PieceScorer:
         return ScoreSnapshot(
             white_material=white,
             black_material=black,
-            white_captured=cls.STARTING_MATERIAL - black,
-            black_captured=cls.STARTING_MATERIAL - white,
+            white_captured=max(0, cls.STARTING_MATERIAL - black),
+            black_captured=max(0, cls.STARTING_MATERIAL - white),
             advantage=white - black,
         )
 

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -69,6 +69,13 @@ class TestSnapshot:
         assert snap.black_captured == 0
 
 
+    def test_captured_material_never_negative_with_promotions(self):
+        # Synthetic board with promoted material beyond starting value.
+        board = chess.Board("QQQQQQQQ/QQQQQQQQ/8/8/8/8/8/k6K w - - 0 1")
+        snap = PieceScorer.snapshot(board)
+        assert snap.black_captured == 0
+
+
 class TestStatusText:
     def test_even_position(self):
         board = chess.Board()


### PR DESCRIPTION
### Motivation
- Prevent captured-material totals from becoming negative in positions where promotions or synthetic setups cause a side's material to exceed the usual starting total.

### Description
- Clamp captured totals in `PieceScorer.snapshot` by using `max(0, STARTING_MATERIAL - opponent_material)` for both `white_captured` and `black_captured` in `game_core/scoring.py`.
- Add a regression test `test_captured_material_never_negative_with_promotions` to `tests/test_scoring.py` that constructs a promotion-heavy board and asserts captured totals are not negative.

### Testing
- Ran the full test suite with `pytest -q`, and all tests passed (`52 passed`).
- The new regression test in `tests/test_scoring.py` also passed under the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69914274d74483249bcb95b3b26146a0)